### PR TITLE
fix: add workaround for chrome bug 816121

### DIFF
--- a/lib/webpack5/RuntimeModules/ChunkLoaderFallback.js
+++ b/lib/webpack5/RuntimeModules/ChunkLoaderFallback.js
@@ -40,7 +40,7 @@ const runtime = function () {
         })
         .then(sendResponse)
     } else {
-      const details = { frameId: sender.frameId, file }
+      const details = { frameId: sender.frameId, file, matchAboutBlank: true }
       if (isBrowser) {
         runtime.tabs.executeScript(sender.tab.id, details).then(sendResponse)
       } else {

--- a/lib/webpack5/RuntimeModules/LoadScript.js
+++ b/lib/webpack5/RuntimeModules/LoadScript.js
@@ -42,15 +42,39 @@ module.exports = function LoadScriptRuntimeModule(webpack, supportDynamicImport,
     generate() {
       const DynamicImportLoader =
         `var ${DYNAMIC_IMPORT_LOADER} = ` +
-        this.f('url, done, chunkId', [
-          `import(url).then(() => done(), ${this.f('e', [
+        this.f('url, done, key, chunkId', [
+          `import(url).then(${this.f('', [
+            `if (isNotIframe) return done()`,
+            `try {`,
+            Template.indent([
+              `// It's a Chrome bug, if the import() is called in a sandboxed iframe, it _fails_ the script loading but _resolve_ the Promise.`,
+              `// we call ${RuntimeGlobals.ensureChunkHandlers}.j(chunkId) to check if it is loaded.`,
+              `// if it is, this is a no-op. if it is not, it will throw a TypeError because this function requires 2 parameters.`,
+              `// This call will not trigger the chunk loading because it is already loading.`,
+              `// see https://github.com/awesome-webextension/webpack-target-webextension/issues/41`,
+              `chunkId !== undefined && ${RuntimeGlobals.ensureChunkHandlers}.j(chunkId)`,
+              `done()`,
+            ]),
+            `}`,
+            `catch {`,
+            Template.indent([
+              `if (!bug816121warned) {`,
+              Template.indent([
+                'console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")',
+                'bug816121warned = true',
+              ]),
+              `}`,
+              `return ${FALLBACK_LOADER}(url, done, key, chunkId)`,
+            ]),
+            `}`,
+          ])}, ${this.f('e', [
             `console.warn('jsonp chunk loader failed to use dynamic import.', e)`,
-            `${FALLBACK_LOADER}(url, done, chunkId)`,
+            `${FALLBACK_LOADER}(url, done, key, chunkId)`,
           ])})`,
         ])
       const DOMLoader =
         `var ${DOM_LOADER} = ` +
-        this.f('url, done, chunkId', [
+        this.f('url, done', [
           `var script = document.createElement('script')`,
           `script.src = url`,
           `script.onload = done`,
@@ -58,11 +82,10 @@ module.exports = function LoadScriptRuntimeModule(webpack, supportDynamicImport,
           `document.body.appendChild(script)`,
         ])
       const WorkerLoader =
-        `var ${WORKER_LOADER} = ` +
-        this.f('url, done, chunkId', [`try { importScripts(url); done() } catch (e) { done(e) }`])
+        `var ${WORKER_LOADER} = ` + this.f('url, done', [`try { importScripts(url); done() } catch (e) { done(e) }`])
       const ClassicLoader =
         `var ${CLASSIC_LOADER} = ` +
-        this.f('url, done, chunkId', [
+        this.f('url, done', [
           `${CLASSIC_SUPPORT}({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))`,
         ])
       const ClassicLoaderSupport =
@@ -79,6 +102,11 @@ module.exports = function LoadScriptRuntimeModule(webpack, supportDynamicImport,
       return Template.asString(
         [
           ...BrowserRuntime(acceptWeak),
+
+          this.supportDynamicImport ? `var bug816121warned, isNotIframe` : undefined,
+          this.supportDynamicImport
+            ? `try { isNotIframe = typeof window === "object" ? window.top === window : true } catch(e) { isInIframe = false /* CORS error */ }`
+            : undefined,
 
           this.classicLoaderEnabled ? ClassicLoaderSupport : '',
           this.classicLoaderEnabled ? ClassicLoader : ClassicLoaderDisabled,

--- a/lib/webpack5/RuntimeModules/LoadScript.js
+++ b/lib/webpack5/RuntimeModules/LoadScript.js
@@ -59,16 +59,13 @@ module.exports = function LoadScriptRuntimeModule(webpack, supportDynamicImport,
             `catch {`,
             Template.indent([
               `if (!bug816121warned) {`,
-              Template.indent([
-                'console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")',
-                'bug816121warned = true',
-              ]),
+              Template.indent(['console.warn("Chrome bug https://crbug.com/816121 hit.")', 'bug816121warned = true']),
               `}`,
               `return ${FALLBACK_LOADER}(url, done, key, chunkId)`,
             ]),
             `}`,
           ])}, ${this.f('e', [
-            `console.warn('jsonp chunk loader failed to use dynamic import.', e)`,
+            `console.warn('Dynamic import loader failed. Using fallback loader (see https://github.com/awesome-webextension/webpack-target-webextension#content-script).', e)`,
             `${FALLBACK_LOADER}(url, done, key, chunkId)`,
           ])})`,
         ])

--- a/tests/snapshot/mv2-basic+esm/background.js
+++ b/tests/snapshot/mv2-basic+esm/background.js
@@ -108,13 +108,13 @@
 /******/ 				}
 /******/ 				catch {
 /******/ 					if (!bug816121warned) {
-/******/ 						console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")
+/******/ 						console.warn("Chrome bug https://crbug.com/816121 hit.")
 /******/ 						bug816121warned = true
 /******/ 					}
 /******/ 					return fallbackLoader(url, done, key, chunkId)
 /******/ 				}
 /******/ 			}, (e) => {
-/******/ 				console.warn('jsonp chunk loader failed to use dynamic import.', e)
+/******/ 				console.warn('Dynamic import loader failed. Using fallback loader (see https://github.com/awesome-webextension/webpack-target-webextension#content-script).', e)
 /******/ 				fallbackLoader(url, done, key, chunkId)
 /******/ 			})
 /******/ 		}

--- a/tests/snapshot/mv2-basic+esm/background.js
+++ b/tests/snapshot/mv2-basic+esm/background.js
@@ -85,27 +85,47 @@
 /******/ 		var isBrowser = !!(() => { try { return browser.runtime.getURL("/") } catch(e) {} })()
 /******/ 		var isChrome = !!(() => { try { return chrome.runtime.getURL("/") } catch(e) {} })()
 /******/ 		var runtime = isBrowser ? browser : isChrome ? chrome : { get runtime() { throw new Error("No chrome or browser runtime found") } }
+/******/ 		var bug816121warned, isNotIframe
+/******/ 		try { isNotIframe = typeof window === "object" ? window.top === window : true } catch(e) { isInIframe = false /* CORS error */ }
 /******/ 		var __send__ = (msg) => {
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var dynamicImportLoader = (url, done, chunkId) => {
-/******/ 			import(url).then(() => done(), (e) => {
+/******/ 		var dynamicImportLoader = (url, done, key, chunkId) => {
+/******/ 			import(url).then(() => {
+/******/ 				if (isNotIframe) return done()
+/******/ 				try {
+/******/ 					// It's a Chrome bug, if the import() is called in a sandboxed iframe, it _fails_ the script loading but _resolve_ the Promise.
+/******/ 					// we call __webpack_require__.f.j(chunkId) to check if it is loaded.
+/******/ 					// if it is, this is a no-op. if it is not, it will throw a TypeError because this function requires 2 parameters.
+/******/ 					// This call will not trigger the chunk loading because it is already loading.
+/******/ 					// see https://github.com/awesome-webextension/webpack-target-webextension/issues/41
+/******/ 					chunkId !== undefined && __webpack_require__.f.j(chunkId)
+/******/ 					done()
+/******/ 				}
+/******/ 				catch {
+/******/ 					if (!bug816121warned) {
+/******/ 						console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")
+/******/ 						bug816121warned = true
+/******/ 					}
+/******/ 					return fallbackLoader(url, done, key, chunkId)
+/******/ 				}
+/******/ 			}, (e) => {
 /******/ 				console.warn('jsonp chunk loader failed to use dynamic import.', e)
-/******/ 				fallbackLoader(url, done, chunkId)
+/******/ 				fallbackLoader(url, done, key, chunkId)
 /******/ 			})
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv2-basic+esm/background.js
+++ b/tests/snapshot/mv2-basic+esm/background.js
@@ -285,7 +285,8 @@
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv2-basic+esm/content.js
+++ b/tests/snapshot/mv2-basic+esm/content.js
@@ -108,13 +108,13 @@
 /******/ 				}
 /******/ 				catch {
 /******/ 					if (!bug816121warned) {
-/******/ 						console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")
+/******/ 						console.warn("Chrome bug https://crbug.com/816121 hit.")
 /******/ 						bug816121warned = true
 /******/ 					}
 /******/ 					return fallbackLoader(url, done, key, chunkId)
 /******/ 				}
 /******/ 			}, (e) => {
-/******/ 				console.warn('jsonp chunk loader failed to use dynamic import.', e)
+/******/ 				console.warn('Dynamic import loader failed. Using fallback loader (see https://github.com/awesome-webextension/webpack-target-webextension#content-script).', e)
 /******/ 				fallbackLoader(url, done, key, chunkId)
 /******/ 			})
 /******/ 		}

--- a/tests/snapshot/mv2-basic+esm/content.js
+++ b/tests/snapshot/mv2-basic+esm/content.js
@@ -85,27 +85,47 @@
 /******/ 		var isBrowser = !!(() => { try { return browser.runtime.getURL("/") } catch(e) {} })()
 /******/ 		var isChrome = !!(() => { try { return chrome.runtime.getURL("/") } catch(e) {} })()
 /******/ 		var runtime = isBrowser ? browser : isChrome ? chrome : { get runtime() { throw new Error("No chrome or browser runtime found") } }
+/******/ 		var bug816121warned, isNotIframe
+/******/ 		try { isNotIframe = typeof window === "object" ? window.top === window : true } catch(e) { isInIframe = false /* CORS error */ }
 /******/ 		var __send__ = (msg) => {
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var dynamicImportLoader = (url, done, chunkId) => {
-/******/ 			import(url).then(() => done(), (e) => {
+/******/ 		var dynamicImportLoader = (url, done, key, chunkId) => {
+/******/ 			import(url).then(() => {
+/******/ 				if (isNotIframe) return done()
+/******/ 				try {
+/******/ 					// It's a Chrome bug, if the import() is called in a sandboxed iframe, it _fails_ the script loading but _resolve_ the Promise.
+/******/ 					// we call __webpack_require__.f.j(chunkId) to check if it is loaded.
+/******/ 					// if it is, this is a no-op. if it is not, it will throw a TypeError because this function requires 2 parameters.
+/******/ 					// This call will not trigger the chunk loading because it is already loading.
+/******/ 					// see https://github.com/awesome-webextension/webpack-target-webextension/issues/41
+/******/ 					chunkId !== undefined && __webpack_require__.f.j(chunkId)
+/******/ 					done()
+/******/ 				}
+/******/ 				catch {
+/******/ 					if (!bug816121warned) {
+/******/ 						console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")
+/******/ 						bug816121warned = true
+/******/ 					}
+/******/ 					return fallbackLoader(url, done, key, chunkId)
+/******/ 				}
+/******/ 			}, (e) => {
 /******/ 				console.warn('jsonp chunk loader failed to use dynamic import.', e)
-/******/ 				fallbackLoader(url, done, chunkId)
+/******/ 				fallbackLoader(url, done, key, chunkId)
 /******/ 			})
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv2-basic-none/background.js
+++ b/tests/snapshot/mv2-basic-none/background.js
@@ -88,14 +88,14 @@
 /******/ 		var classicLoader = () => {
 /******/ 			throw new Error("No loader for content script is found. You must set output.environment.dynamicImport to enable ES Module loader, or specify the background entry in your webpack config to enable the classic loader.")
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv2-basic-none/content.js
+++ b/tests/snapshot/mv2-basic-none/content.js
@@ -88,14 +88,14 @@
 /******/ 		var classicLoader = () => {
 /******/ 			throw new Error("No loader for content script is found. You must set output.environment.dynamicImport to enable ES Module loader, or specify the background entry in your webpack config to enable the classic loader.")
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv2-basic/background.js
+++ b/tests/snapshot/mv2-basic/background.js
@@ -89,17 +89,17 @@
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv2-basic/background.js
+++ b/tests/snapshot/mv2-basic/background.js
@@ -257,7 +257,8 @@
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv2-basic/content.js
+++ b/tests/snapshot/mv2-basic/content.js
@@ -89,17 +89,17 @@
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv3-basic+esm/background.js
+++ b/tests/snapshot/mv3-basic+esm/background.js
@@ -180,7 +180,8 @@
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv3-basic+esm/content.js
+++ b/tests/snapshot/mv3-basic+esm/content.js
@@ -108,13 +108,13 @@
 /******/ 				}
 /******/ 				catch {
 /******/ 					if (!bug816121warned) {
-/******/ 						console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")
+/******/ 						console.warn("Chrome bug https://crbug.com/816121 hit.")
 /******/ 						bug816121warned = true
 /******/ 					}
 /******/ 					return fallbackLoader(url, done, key, chunkId)
 /******/ 				}
 /******/ 			}, (e) => {
-/******/ 				console.warn('jsonp chunk loader failed to use dynamic import.', e)
+/******/ 				console.warn('Dynamic import loader failed. Using fallback loader (see https://github.com/awesome-webextension/webpack-target-webextension#content-script).', e)
 /******/ 				fallbackLoader(url, done, key, chunkId)
 /******/ 			})
 /******/ 		}

--- a/tests/snapshot/mv3-basic+esm/content.js
+++ b/tests/snapshot/mv3-basic+esm/content.js
@@ -85,27 +85,47 @@
 /******/ 		var isBrowser = !!(() => { try { return browser.runtime.getURL("/") } catch(e) {} })()
 /******/ 		var isChrome = !!(() => { try { return chrome.runtime.getURL("/") } catch(e) {} })()
 /******/ 		var runtime = isBrowser ? browser : isChrome ? chrome : { get runtime() { throw new Error("No chrome or browser runtime found") } }
+/******/ 		var bug816121warned, isNotIframe
+/******/ 		try { isNotIframe = typeof window === "object" ? window.top === window : true } catch(e) { isInIframe = false /* CORS error */ }
 /******/ 		var __send__ = (msg) => {
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var dynamicImportLoader = (url, done, chunkId) => {
-/******/ 			import(url).then(() => done(), (e) => {
+/******/ 		var dynamicImportLoader = (url, done, key, chunkId) => {
+/******/ 			import(url).then(() => {
+/******/ 				if (isNotIframe) return done()
+/******/ 				try {
+/******/ 					// It's a Chrome bug, if the import() is called in a sandboxed iframe, it _fails_ the script loading but _resolve_ the Promise.
+/******/ 					// we call __webpack_require__.f.j(chunkId) to check if it is loaded.
+/******/ 					// if it is, this is a no-op. if it is not, it will throw a TypeError because this function requires 2 parameters.
+/******/ 					// This call will not trigger the chunk loading because it is already loading.
+/******/ 					// see https://github.com/awesome-webextension/webpack-target-webextension/issues/41
+/******/ 					chunkId !== undefined && __webpack_require__.f.j(chunkId)
+/******/ 					done()
+/******/ 				}
+/******/ 				catch {
+/******/ 					if (!bug816121warned) {
+/******/ 						console.warn("Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121 hit.")
+/******/ 						bug816121warned = true
+/******/ 					}
+/******/ 					return fallbackLoader(url, done, key, chunkId)
+/******/ 				}
+/******/ 			}, (e) => {
 /******/ 				console.warn('jsonp chunk loader failed to use dynamic import.', e)
-/******/ 				fallbackLoader(url, done, chunkId)
+/******/ 				fallbackLoader(url, done, key, chunkId)
 /******/ 			})
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv3-basic-no-dynamic-import/background.js
+++ b/tests/snapshot/mv3-basic-no-dynamic-import/background.js
@@ -110,7 +110,8 @@ const x = 1
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv3-basic/background.js
+++ b/tests/snapshot/mv3-basic/background.js
@@ -180,7 +180,8 @@
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv3-basic/content.js
+++ b/tests/snapshot/mv3-basic/content.js
@@ -89,17 +89,17 @@
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv3-both/background.js
+++ b/tests/snapshot/mv3-both/background.js
@@ -89,17 +89,17 @@
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'

--- a/tests/snapshot/mv3-both/background.js
+++ b/tests/snapshot/mv3-both/background.js
@@ -257,7 +257,8 @@
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv3-both/backgroundWorker.js
+++ b/tests/snapshot/mv3-both/backgroundWorker.js
@@ -180,7 +180,8 @@
 /******/ 		    } else {
 /******/ 		      const details = {
 /******/ 		        frameId: sender.frameId,
-/******/ 		        file
+/******/ 		        file,
+/******/ 		        matchAboutBlank: true
 /******/ 		      };
 /******/ 		
 /******/ 		      if (isBrowser) {

--- a/tests/snapshot/mv3-both/content.js
+++ b/tests/snapshot/mv3-both/content.js
@@ -89,17 +89,17 @@
 /******/ 			if (isBrowser) return runtime.runtime.sendMessage(msg)
 /******/ 			return new Promise(r => runtime.runtime.sendMessage(msg, r))
 /******/ 		}
-/******/ 		var classicLoader = (url, done, chunkId) => {
+/******/ 		var classicLoader = (url, done) => {
 /******/ 			__send__({ type: 'WTW_INJECT', file: url }).then(done, (e) => done(Object.assign(e, { type: 'missing' })))
 /******/ 		}
-/******/ 		var scriptLoader = (url, done, chunkId) => {
+/******/ 		var scriptLoader = (url, done) => {
 /******/ 			var script = document.createElement('script')
 /******/ 			script.src = url
 /******/ 			script.onload = done
 /******/ 			script.onerror = done
 /******/ 			document.body.appendChild(script)
 /******/ 		}
-/******/ 		var workerLoader = (url, done, chunkId) => {
+/******/ 		var workerLoader = (url, done) => {
 /******/ 			try { importScripts(url); done() } catch (e) { done(e) }
 /******/ 		}
 /******/ 		var isWorker = typeof importScripts === 'function'


### PR DESCRIPTION
a dirty hack to workaround Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=816121

this dirty hack tries to detect this bug and fix it by calling the classic loader, therefore you must have the correct permissions (like "scripting" in mv3) and host_permissions of the target origin.

you can see the document of classic loader in the readme of this project.