### PR TITLE
hot-reloading doesn't remove old versions of content scripts

### DIFF
--- a/examples/code-dom-injection/background.js
+++ b/examples/code-dom-injection/background.js
@@ -1,0 +1,1 @@
+console.log('hello from the background!')

--- a/examples/code-dom-injection/content.js
+++ b/examples/code-dom-injection/content.js
@@ -1,0 +1,37 @@
+// Enable HMR if available
+if (module.hot) {
+  module.hot.accept()
+}
+
+// Main content script logic
+console.log('hello from content_scripts')
+
+document.body.innerHTML += `
+  <style>
+    .content_script {
+      color: #c9c9c9;
+      background-color: #0a0c10;
+      position: fixed;
+      right: 0;
+      bottom: 0;
+      z-index: 9;
+      width: 315px;
+      margin: 1rem;
+      padding: 2rem 1rem;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .content_title {
+      font-size: 1.85em;
+      line-height: 1.1;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+      font-weight: 700;
+    }
+  </style>
+
+  <div class="content_script">
+    <h1 class="content_title">Welcome to your Content Script Extension</h1>
+  </div>
+`

--- a/examples/code-dom-injection/manifest.json
+++ b/examples/code-dom-injection/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Web Extension webpack HMR test",
+  "version": "1.0.0",
+  "background": {
+    "service_worker": "./dist/background.js"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["/dist/*.txt", "/dist/*.json"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["./dist/content.js"]
+    }
+  ],
+  "permissions": ["scripting"],
+  "host_permissions": ["<all_urls>"]
+}

--- a/examples/code-dom-injection/package.json
+++ b/examples/code-dom-injection/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "start": "npx webpack serve --mode development",
+    "build": "npx webpack --mode production"
+  }
+}

--- a/examples/code-dom-injection/webpack.config.js
+++ b/examples/code-dom-injection/webpack.config.js
@@ -1,0 +1,35 @@
+const WebExtension = require('webpack-target-webextension')
+const webpack = require('webpack')
+const { join } = require('path')
+
+/** @type {webpack.Configuration} */
+const config = {
+  // No eval allowed in MV3
+  devtool: 'cheap-source-map',
+  entry: {
+    content: join(__dirname, './content.js'),
+    background: join(__dirname, './background.js'),
+  },
+  optimization: {
+    // minimize: false,
+  },
+  output: {
+    path: join(__dirname, './dist'),
+    // Our assets are emitted in /dist folder of our web extension.
+    publicPath: '/dist/',
+  },
+  plugins: [
+    new WebExtension({
+      background: {
+        entry: 'background',
+        // !! Add this to support manifest v3
+        manifest: 3,
+      },
+    }),
+  ],
+  // Add devServer.hot = true or "only" to enable HMR.
+  devServer: {
+    hot: 'only',
+  },
+}
+module.exports = config


### PR DESCRIPTION
hey there! it seems `webpack-target-webextension` doesn't emove old versions of content scripts when using `module.hot.accept()`. This PR adds a sample that can reproduce. it seems an issue with both `.js` and `.ts` extensions.

Steps to Reproduce:

- Pull the code
- Edit the injected DOM in `content.js`
- Actual Result: 
  - **one time:** works;
  - **two times:** Injected DOM node piles up, console.logs too
- Expected Result: Auto cleanup on file changes. Similar to how the `react-hmr` example works

<img width="780" alt="Screenshot 2024-10-26 at 11 09 37" src="https://github.com/user-attachments/assets/83912ec3-1b7a-404b-8ca4-5d1c556072b8">
